### PR TITLE
fix: upgrade eslint to ^10 to resolve ERESOLVE build failure

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -70,7 +70,7 @@
       "@types/react": "^19.2.14",
       "@types/react-dom": "^19.2.3",
       "autoprefixer": "10.4.20",
-      "eslint": "9.12.0",
+      "eslint": "^10.0.0",
       "eslint-config-next": "^16.2.4",
       "postcss": "8.4.47",
       "prettier": "^3.3.3",

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -72,7 +72,7 @@
       "@types/react": "^19.2.14",
       "@types/react-dom": "^19.2.3",
       "autoprefixer": "^10.4.20",
-      "eslint": "9.12.0",
+      "eslint": "^10.0.0",
       "eslint-config-next": "^16.2.4",
       "postcss": "^8.4.47",
       "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "@trivago/prettier-plugin-sort-imports": "^4.3.0",
       "@typescript-eslint/eslint-plugin": "^8.8.1",
       "@typescript-eslint/parser": "^8.8.1",
-      "eslint": "^9.12.0",
+      "eslint": "^10.0.0",
       "eslint-config-next": "^14.2.15",
       "eslint-plugin-react": "^7.37.1",
       "husky": "^9.1.6",


### PR DESCRIPTION
## Summary

- Upgrades eslint from 9.12.0 to ^10.0.0 in root, admin, and storefront package.json
- Resolves ERESOLVE peer dependency conflict between eslint@9.12.0 and @eslint/js@10.0.1 (which requires eslint@^10.0.0)
- Fixes Vercel deploy build failure