### PR TITLE
fix: upgrade @radix-ui/react-icons to ^1.3.2 for React 19 peer support

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -28,7 +28,7 @@
       "@radix-ui/react-checkbox": "^1.1.2",
       "@radix-ui/react-dialog": "^1.1.2",
       "@radix-ui/react-dropdown-menu": "^2.1.2",
-      "@radix-ui/react-icons": "^1.3.0",
+      "@radix-ui/react-icons": "^1.3.2",
       "@radix-ui/react-label": "^2.1.0",
       "@radix-ui/react-navigation-menu": "^1.2.14",
       "@radix-ui/react-popover": "^1.1.2",

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -31,7 +31,7 @@
       "@radix-ui/react-checkbox": "^1.1.2",
       "@radix-ui/react-dialog": "^1.1.2",
       "@radix-ui/react-dropdown-menu": "^2.1.2",
-      "@radix-ui/react-icons": "^1.3.0",
+      "@radix-ui/react-icons": "^1.3.2",
       "@radix-ui/react-label": "^2.1.0",
       "@radix-ui/react-navigation-menu": "^1.2.1",
       "@radix-ui/react-popover": "^1.1.2",


### PR DESCRIPTION
## Summary

- Upgrades @radix-ui/react-icons from ^1.3.0 to ^1.3.2 to add React 19 peer dependency support
- Resolves ERESOLVE build failure on Vercel (radix-ui/react-icons@1.3.0 only supports React ^16/^17/^18)