### PR TITLE
fix: set packageManager to pnpm for Vercel build detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
       "name": "Sesto",
       "url": "https://github.com/sesto-dev"
    },
-   "license": "MIT",
+    "packageManager": "pnpm@10.32.1",
+    "license": "MIT",
    "devDependencies": {
       "@commitlint/cli": "^19.5.0",
       "@commitlint/config-conventional": "^19.5.0",


### PR DESCRIPTION
## Summary

- Adds packageManager field to root package.json pointing to pnpm@10.32.1
- Tells Vercel to use pnpm instead of npm (which causes ERESOLVE peer dep conflicts with React 19)
- Root cause of all ERESOLVE failures: Vercel was using npm due to missing root pnpm lockfile