### PR TITLE
fix: add pnpm overrides to admin package.json

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -80,6 +80,13 @@
       "tailwind-merge": "^2.5.3",
       "tailwindcss": "3.4.13",
       "tailwindcss-animate": "^1.0.7",
-      "typescript": "5.6.3"
-   }
+       "typescript": "5.6.3"
+    },
+    "pnpm": {
+       "overrides": {
+          "@eslint/plugin-kit@<0.3.4": ">=0.3.4",
+          "effect@<3.20.0": ">=3.20.0",
+          "postcss@<8.5.10": ">=8.5.10"
+       }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds pnpm.overrides section to admin package.json matching the existing pnpm-lock.yaml
- Fixes ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on Vercel builds
- Overrides were auto-generated in lockfile by pnpm security audits but missing from package.json