### PR TITLE
fix: add missing @persepolis/regex dependency to admin

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -22,7 +22,8 @@
    },
    "dependencies": {
       "@hookform/resolvers": "^3.9.0",
-      "@persepolis/ui": "^0.1.9",
+       "@persepolis/ui": "^0.1.9",
+       "@persepolis/regex": "^0.0.3",
       "@prisma/client": "^5.20.0",
       "@radix-ui/react-accordion": "^1.2.1",
       "@radix-ui/react-avatar": "^1.1.1",

--- a/apps/admin/pnpm-lock.yaml
+++ b/apps/admin/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.10.0(react-hook-form@7.75.0(react@19.2.5))
+      '@persepolis/regex':
+        specifier: ^0.0.3
+        version: 0.0.3(@types/node@22.7.5)
       '@persepolis/ui':
         specifier: ^0.1.9
         version: 0.1.9(react@19.2.5)
@@ -669,6 +672,11 @@ packages:
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
+
+  '@persepolis/regex@0.0.3':
+    resolution: {integrity: sha512-iG038MVBYPwNaUnBqOY6xvImZK2hu8pqmYm0eYjCDdptONnE1fS7vPO3MbD3NESL2bp8Ma7ulkQRQInml/C5AA==}
+    peerDependencies:
+      '@types/node': ^20.6.2
 
   '@persepolis/ui@0.1.9':
     resolution: {integrity: sha512-gLpayH85xMcFJjCfh3TjwSSyKL2a0588KYdruexEiauAe5G+eACuMacvwBkomnMNjwe8lQOj1RdVJEr3e0SRmQ==}
@@ -3666,6 +3674,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@persepolis/regex@0.0.3(@types/node@22.7.5)':
+    dependencies:
+      '@types/node': 22.7.5
 
   '@persepolis/ui@0.1.9(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds @persepolis/regex to admin package.json
- Required by src/app/login/components/user-auth-form.tsx for email/phone validation
- Was imported but missing from dependencies, causing TypeScript build failure on Vercel
- Build verified locally - passes successfully