### PR TITLE
feat: add CORS headers for cross-app API access

### DIFF
--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -13,4 +13,17 @@ module.exports = {
          },
       ],
    },
+   async headers() {
+      return [
+         {
+            source: '/api/:path*',
+            headers: [
+               { key: 'Access-Control-Allow-Origin', value: 'https://eafcautos.vercel.app' },
+               { key: 'Access-Control-Allow-Methods', value: 'GET, POST, PUT, DELETE, OPTIONS' },
+               { key: 'Access-Control-Allow-Headers', value: 'Content-Type, Authorization' },
+               { key: 'Access-Control-Max-Age', value: '86400' },
+            ],
+         },
+      ]
+   },
 }

--- a/apps/storefront/next.config.js
+++ b/apps/storefront/next.config.js
@@ -13,6 +13,19 @@ module.exports = {
             },
         ],
     },
+    async headers() {
+        return [
+            {
+                source: '/api/:path*',
+                headers: [
+                    { key: 'Access-Control-Allow-Origin', value: 'https://eafcautosadmin.vercel.app' },
+                    { key: 'Access-Control-Allow-Methods', value: 'GET, POST, PUT, DELETE, OPTIONS' },
+                    { key: 'Access-Control-Allow-Headers', value: 'Content-Type, Authorization' },
+                    { key: 'Access-Control-Max-Age', value: '86400' },
+                ],
+            },
+        ]
+    },
     async redirects() {
         return [
             {


### PR DESCRIPTION
## Summary

- Storefront API allows requests from https://eafcautosadmin.vercel.app
- Admin API allows requests from https://eafcautos.vercel.app
- Adds NEXT_PUBLIC_STOREFRONT_URL to admin .env for storefront reference
- CORS headers applied via next.config.js headers() for all /api/:path* routes

Note: admin .env is gitignored — set NEXT_PUBLIC_STOREFRONT_URL manually in Vercel dashboard