### PR TITLE
fix: disable page caching on all admin dashboard routes

### DIFF
--- a/apps/admin/src/app/(dashboard)/(routes)/layout.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/layout.tsx
@@ -1,0 +1,7 @@
+// Force all admin routes to be dynamic (no caching)
+// This ensures data always reflects latest DB state
+export const dynamic = 'force-dynamic'
+
+export default function RoutesLayout({ children }: { children: React.ReactNode }) {
+   return children
+}


### PR DESCRIPTION
## Summary

- Adds (routes)/layout.tsx with dynamic = force-dynamic
- Ensures all admin pages always fetch fresh data from DB on every request
- Root cause: Next.js 16 caches server components by default, causing stale data to show after CRUD operations in production
- Local dev works because Next.js dev server disables caching