### PR TITLE
feat: delete UploadThing images on car delete

### DIFF
--- a/apps/admin/src/app/api/cars/[carId]/route.ts
+++ b/apps/admin/src/app/api/cars/[carId]/route.ts
@@ -1,5 +1,8 @@
 import prisma from '@/lib/prisma'
 import { NextResponse } from 'next/server'
+import { UTApi } from 'uploadthing/server'
+
+const utapi = new UTApi()
 
 export async function PATCH(req: Request, props: { params: Promise<{ carId: string }> }) {
    const params = await props.params;
@@ -44,11 +47,31 @@ export async function DELETE(req: Request, props: { params: Promise<{ carId: str
    const params = await props.params;
    try {
       if (!params.carId) { return new NextResponse('Car ID required', { status: 400 }) }
-      const car = await prisma.car.update({
+
+      const car = await prisma.car.findUnique({
+         where: { id: params.carId },
+         select: { images: true },
+      })
+      if (!car) { return new NextResponse('Car not found', { status: 404 }) }
+
+      const keys = (car.images as string[])
+         .map((url: string) => {
+            const m = url.match(/\/f\/([^/?#]+)/)
+            return m ? m[1] : null
+         })
+         .filter(Boolean) as string[]
+
+      if (keys.length > 0) {
+         await utapi.deleteFiles(keys).catch((err) =>
+            console.error('[UT_DELETE]', err),
+         )
+      }
+
+      const updated = await prisma.car.update({
          where: { id: params.carId },
          data: { isDeleted: true },
       })
-      return NextResponse.json(car)
+      return NextResponse.json(updated)
    } catch (error) {
       console.error('[CARS_DELETE]', error)
       return new NextResponse('Internal error', { status: 500 })


### PR DESCRIPTION
## Changes

- Import UTApi from uploadthing/server in car delete route
- Fetch car images before soft-deleting
- Extract UploadThing file keys from image URLs (pattern: /f/{key})
- Call utapi.deleteFiles(keys) to remove images from bucket
- Then soft-delete the car in DB

## How it works

1. Fetch car + images from DB
2. Extract UFS file keys from each image URL
3. Delete files from UploadThing storage
4. Soft-delete the car

Fixes: #46