### PR TITLE
refactor: navbar UI cleanup

### DIFF
--- a/apps/storefront/src/app/(store)/(routes)/cars/[slug]/page.tsx
+++ b/apps/storefront/src/app/(store)/(routes)/cars/[slug]/page.tsx
@@ -157,24 +157,25 @@ function CarDetails({
 
    return (
       <div className="space-y-6">
-         <div>
-             <div className="flex gap-2 flex-wrap mb-2">
-                <Badge variant="outline">{car.brand.title}</Badge>
-                <Badge variant="secondary">{car.condition}</Badge>
-                {car.year && <Badge variant="secondary">{car.year}</Badge>}
-                {car.isNegotiable && (
-                   <Badge className="bg-green-600 text-white hover:bg-green-700">Negotiable</Badge>
-                )}
-             </div>
+          <div>
+              <div className="flex gap-2 flex-wrap mb-2">
+                 <Badge variant="outline">{car.brand.title}</Badge>
+                 <Badge variant="secondary">{car.condition}</Badge>
+                 {car.year && <Badge variant="secondary">{car.year}</Badge>}
+                 {car.isNegotiable && (
+                    <Badge className="bg-green-600 text-white hover:bg-green-700">Negotiable</Badge>
+                 )}
+              </div>
               <h1 className="text-subheading font-bold">{car.title}</h1>
-              <p className="text-body-lg font-semibold text-primary mt-2">
-                {formatPrice(car.price)}
-             </p>
-         </div>
-
-          {whatsappUrl && (
-               <WhatsAppDetailButton carId={car.id} href={whatsappUrl} />
-          )}
+              <div className="mt-2 space-y-4">
+                 <p className="text-body-lg font-semibold text-primary">
+                    {formatPrice(car.price)}
+                 </p>
+                 {whatsappUrl && (
+                    <WhatsAppDetailButton carId={car.id} href={whatsappUrl} />
+                 )}
+              </div>
+          </div>
 
          {hasSpecs && (
             <>

--- a/apps/storefront/src/components/native/Footer.tsx
+++ b/apps/storefront/src/components/native/Footer.tsx
@@ -4,11 +4,11 @@ import { Facebook, Instagram, Send, MessageCircle, Music2 } from 'lucide-react'
 import Link from 'next/link'
 
 const socialLinks = [
-   { label: 'Facebook', href: '#', icon: Facebook },
-   { label: 'TikTok', href: '#', icon: Music2 },
-   { label: 'Instagram', href: '#', icon: Instagram },
-   { label: 'Telegram', href: '#', icon: Send },
-   { label: 'WhatsApp', href: '#', icon: MessageCircle },
+   { label: 'Instagram', href: 'https://www.instagram.com/ea.firstclassautos?utm_source=qr', icon: Instagram },
+   { label: 'Facebook', href: 'https://web.facebook.com/andronicus.annan', icon: Facebook },
+   { label: 'TikTok', href: 'https://www.tiktok.com/@ea.firstclassautos?_r=1&_t=ZS-95y9dRwFs4m', icon: Music2 },
+   { label: 'WhatsApp', href: 'https://whatsapp.com/channel/0029Vb7Vz6tLSmbdanhstD2v', icon: MessageCircle },
+   { label: 'Telegram', href: 'https://t.me/eafirstclassautos', icon: Send },
 ]
 
 export default function Footer() {

--- a/apps/storefront/src/components/native/WhatsAppDetailButton.tsx
+++ b/apps/storefront/src/components/native/WhatsAppDetailButton.tsx
@@ -24,7 +24,7 @@ export function WhatsAppDetailButton({
       target="_blank"
       rel="noopener noreferrer"
       onClick={handleClick}
-      className="flex justify-center"
+       className="flex"
     >
       <Button className="w-auto min-h-[44px] gap-2">
         <img

--- a/apps/storefront/src/components/native/nav/mobile.tsx
+++ b/apps/storefront/src/components/native/nav/mobile.tsx
@@ -38,13 +38,17 @@ export function MobileNav() {
                <SheetDescription className="sr-only">Site navigation menu</SheetDescription>
 
                <div className="flex flex-col h-full">
-                  <div className="bg-black px-6 py-3 flex items-center justify-between">
-                     <Link href="/" onClick={() => setOpen(false)} className="inline-block">
-                        <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-white">
-                           EA First Class Autos
-                        </span>
-                     </Link>
-                  </div>
+                   <div className="bg-black px-6 py-3 flex items-center">
+                      <Link href="/" onClick={() => setOpen(false)} className="inline-block">
+                         <Image
+                            src="/ea.jpg"
+                            alt={Config.name}
+                            width={140}
+                            height={40}
+                            className="h-10 w-auto object-contain"
+                         />
+                      </Link>
+                   </div>
 
                   <div className="h-px bg-black" />
 

--- a/apps/storefront/src/components/native/nav/parent.tsx
+++ b/apps/storefront/src/components/native/nav/parent.tsx
@@ -8,7 +8,7 @@ export default function Header() {
       <header className="sticky top-0 z-[40] w-full">
          <div className="bg-black py-1.5 px-[1.4rem] md:px-[4rem] lg:px-[6rem] xl:px-[8rem] 2xl:px-[12rem]">
             <div className="flex items-center justify-between">
-               <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-white/60">
+                <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-white">
                   Ghana's Trusted Auto Dealer
                </span>
                <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-white/40 hidden sm:block">

--- a/apps/storefront/src/components/native/nav/parent.tsx
+++ b/apps/storefront/src/components/native/nav/parent.tsx
@@ -11,7 +11,7 @@ export default function Header() {
                 <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-white">
                   Ghana's Trusted Auto Dealer
                </span>
-               <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-white/40 hidden sm:block">
+                <span className="text-[11px] font-bold uppercase tracking-[0.12em] text-white hidden sm:block">
                   Quality &bull; Trust &bull; Value
                </span>
             </div>


### PR DESCRIPTION
## Changes

- **Hero text:** \Ghana's trusted auto dealer\ now white (was semi-transparent)
- **Hero subtext:** \Quality • Trust • Value\ now white too
- **Mobile nav:** Replaced \EA First Class Autos\ text with logo image in hamburger menu header

## Screenshots needed
- [ ] Mobile nav shows logo instead of text
- [ ] Hero text is white on dark bg