### PR TITLE
fix: revalidate car pages after admin update

### DIFF
--- a/apps/admin/src/app/api/cars/[carId]/route.ts
+++ b/apps/admin/src/app/api/cars/[carId]/route.ts
@@ -1,5 +1,6 @@
 import prisma from '@/lib/prisma'
 import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
 import { UTApi } from 'uploadthing/server'
 
 const utapi = new UTApi()
@@ -36,7 +37,9 @@ export async function PATCH(req: Request, props: { params: Promise<{ carId: stri
          updateData.title = title
       }
       const car = await prisma.car.update({ where: { id: params.carId }, data: updateData })
-      return NextResponse.json(car)
+       revalidatePath(`/cars/${car.slug}`)
+       revalidatePath('/cars')
+       return NextResponse.json(car)
    } catch (error) {
       console.error('[CARS_PATCH]', error)
       return new NextResponse('Internal error', { status: 500 })


### PR DESCRIPTION
## Summary

- Add `revalidatePath` calls to admin PATCH `/api/cars/[carId]` endpoint
- Fixes stale static pages when admin updates car details (price, etc.)

## Problem

When admin updates a car's price, the change reflected on the car listing cards but **NOT** on the car detail page.

**Root cause:** The detail page (`cars/[slug]/page.tsx`) uses `generateStaticParams()` with no revalidation period. Once statically generated at build time, pages serve cached HTML forever.

## Solution

Added `revalidatePath()` calls after successful car update:
- `revalidatePath(\`/cars/${car.slug}\`)` - purges the specific car detail page
- `revalidatePath('/cars')` - purges the cars listing page

This ensures Next.js cache is purged when admin updates car data, so fresh data is served on the next request.

## Testing

- [x] TypeScript compiles without errors
- [ ] Manual test: Update car price in admin → verify detail page shows new price

## Related

Fixes bug reported by user where price updates only reflected on cards, not detail page.
