### PR TITLE
0-schema-and-seed — E-commerce schema migration and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ graphify-out/
 .claude/
 .playwright/
 .qwen/
+
+# worktrees
+.worktrees/

--- a/apps/storefront/prisma/schema.prisma
+++ b/apps/storefront/prisma/schema.prisma
@@ -11,77 +11,276 @@ model Admin {
   id           String   @id @default(cuid())
   email        String   @unique
   passwordHash String
-  name        String?
+  name         String?
   createdAt    DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-}
+  updatedAt    DateTime @updatedAt
 
-model Brand {
-  id          String     @id @default(cuid())
-  title       String     @unique
-  description String?
-  logo        String?
-  cars       Car[]
-  createdAt   DateTime   @default(now())
-  updatedAt  DateTime   @updatedAt
-}
-
-model Car {
-  id             String     @id @default(cuid())
-  title          String
-  slug           String     @unique
-  model          String?
-  year           Int?
-  price          Float
-  isNegotiable    Boolean    @default(false)
-  condition      String     @default("Local Used")
-  description    String?    @db.Text
-  specifications Json?
-  images         String[]
-  whatsappNumber String?
-  isAvailable    Boolean    @default(true)
-  isDeleted      Boolean    @default(false)
-
-  brand      Brand      @relation(fields: [brandId], references: [id])
-  brandId    String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  whatsappClicks WhatsappClick[]
-
-  @@index([brandId])
-  @@index([slug])
+  categories    Category[]
+  suppliers     Supplier[]
+  products      Product[]
+  orders        Order[]
 }
 
 model Banner {
-  id          String    @id @default(cuid())
+  id          String   @id @default(cuid())
   title       String
   image       String
   description String?
-  link       String?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  link        String?
+  isActive    Boolean  @default(true)
+  position    Int      @default(0)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model SiteConfig {
   id              String  @id @default(cuid())
-  defaultWhatsApp String?
-  businessName    String?
-  businessAddress String?
-  businessPhone  String?
-  businessEmail   String?
+  key             String  @unique
+  value           String?
 }
 
 model WhatsappClick {
   id        String   @id @default(cuid())
-  carId     String
-  source    String
+  source    String?
+  productId String?
   createdAt DateTime @default(now())
 
-  car Car @relation(fields: [carId], references: [id])
-
-  @@index([carId])
+  @@index([productId])
   @@index([createdAt])
+}
+
+model Category {
+  id          String    @id @default(cuid())
+  name        String
+  slug        String    @unique @default(cuid())
+  description String?   @db.Text
+  image       String?
+  type        CategoryType @default(STANDARD)
+  isActive    Boolean   @default(true)
+  position    Int       @default(0)
+
+  admin     Admin      @relation(fields: [adminId], references: [id])
+  adminId   String
+
+  products  Product[]
+
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  @@index([slug])
+  @@index([adminId])
+}
+
+enum CategoryType {
+  STANDARD
+  VARIANT
+}
+
+model Supplier {
+  id        String   @id @default(cuid())
+  name      String
+  phone     String?
+  email     String?
+  address   String?  @db.Text
+
+  admin   Admin     @relation(fields: [adminId], references: [id])
+  adminId String
+
+  products Product[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([adminId])
+}
+
+model Product {
+  id          String    @id @default(cuid())
+  name        String
+  slug        String    @unique @default(cuid())
+  brand       String?
+  description String?   @db.Text
+  price       Float
+  stock       Int       @default(0)
+  isActive    Boolean   @default(true)
+
+  images ProductImage[]
+
+  supplier   Supplier? @relation(fields: [supplierId], references: [id])
+  supplierId String?
+
+  category   Category?  @relation(fields: [categoryId], references: [id])
+  categoryId String?
+
+  admin   Admin     @relation(fields: [adminId], references: [id])
+  adminId String
+
+  variants      ProductVariant[]
+  orderItems    OrderItem[]
+  cartItems     CartItem[]
+  wishlistItems WishlistItem[]
+
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  @@index([slug])
+  @@index([supplierId])
+  @@index([categoryId])
+  @@index([adminId])
+}
+
+model ProductVariant {
+  id         String   @id @default(cuid())
+  size       String?
+  color      String?
+  extraPrice Float   @default(0)
+  stock      Int      @default(0)
+
+  product   Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
+  productId String
+
+  orderItems OrderItem[]
+  cartItems  CartItem[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([productId])
+}
+
+model ProductImage {
+  id        String  @id @default(cuid())
+  url       String
+  position  Int     @default(0)
+
+  product   Product @relation(fields: [productId], references: [id], onDelete: Cascade)
+  productId String
+
+  @@index([productId])
+}
+
+model Customer {
+  id           String   @id @default(cuid())
+  name         String
+  email        String?  @unique
+  phone        String?  @unique
+  passwordHash String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  orders        Order[]
+  cartItems     CartItem[]
+  wishlistItems WishlistItem[]
+}
+
+model Order {
+  id              String        @id @default(cuid())
+  customerName    String
+  customerPhone   String
+  customerAddress String?       @db.Text
+  deliveryFee     Float         @default(0)
+  paymentMethod   PaymentMethod @default(COD)
+  paymentStatus   PaymentStatus @default(PENDING)
+  status          OrderStatus   @default(PENDING)
+  totalAmount     Float         @default(0)
+
+  customer   Customer? @relation(fields: [customerId], references: [id])
+  customerId String?
+
+  admin   Admin     @relation(fields: [adminId], references: [id])
+  adminId String
+
+  items OrderItem[]
+
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  @@index([customerId])
+  @@index([adminId])
+}
+
+enum PaymentMethod {
+  PAYSTACK
+  COD
+}
+
+enum PaymentStatus {
+  PENDING
+  PAID
+  FAILED
+  REFUNDED
+}
+
+enum OrderStatus {
+  PENDING
+  CONFIRMED
+  PROCESSING
+  SHIPPED
+  DELIVERED
+  CANCELLED
+}
+
+model OrderItem {
+  id        String   @id @default(cuid())
+  quantity  Int
+  price     Float
+
+  order   Order   @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  orderId String
+
+  product   Product  @relation(fields: [productId], references: [id])
+  productId String
+
+  variant   ProductVariant? @relation(fields: [variantId], references: [id])
+  variantId String?
+
+  createdAt DateTime @default(now())
+
+  @@index([orderId])
+  @@index([productId])
+  @@index([variantId])
+}
+
+model CartItem {
+  id        String   @id @default(cuid())
+  quantity  Int      @default(1)
+
+  sessionId String?
+
+  customer   Customer? @relation(fields: [customerId], references: [id])
+  customerId String?
+
+  product   Product  @relation(fields: [productId], references: [id])
+  productId String
+
+  variant   ProductVariant? @relation(fields: [variantId], references: [id])
+  variantId String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([sessionId])
+  @@index([customerId])
+  @@index([productId])
+  @@index([variantId])
+}
+
+model WishlistItem {
+  id        String   @id @default(cuid())
+
+  sessionId String?
+
+  customer   Customer? @relation(fields: [customerId], references: [id])
+  customerId String?
+
+  product   Product  @relation(fields: [productId], references: [id])
+  productId String
+
+  createdAt DateTime @default(now())
+
+  @@unique([sessionId, productId])
+  @@unique([customerId, productId])
+  @@index([sessionId])
+  @@index([customerId])
+  @@index([productId])
 }

--- a/apps/storefront/prisma/seed.ts
+++ b/apps/storefront/prisma/seed.ts
@@ -1,254 +1,720 @@
 import { PrismaClient } from '@prisma/client'
-import bcrypt from 'bcryptjs'
 
 const prisma = new PrismaClient()
 
 async function main() {
-  const email = process.env.ADMIN_EMAIL || 'admin@example.com'
-  const password = process.env.ADMIN_PASSWORD || 'admin123'
-  const name = process.env.ADMIN_NAME || 'Admin'
+  console.log('Starting seed...')
 
-  const passwordHash = await bcrypt.hash(password, 10)
-
+  // Create admin
   const admin = await prisma.admin.upsert({
-    where: { email },
+    where: { email: 'admin@firstclassautos.com' },
     update: {},
     create: {
-      email,
-      passwordHash,
-      name,
+      email: 'admin@firstclassautos.com',
+      passwordHash: '$2a$10$dummyhashfortestingonly1234567890abcdefghijklmnop',
+      name: 'Admin User',
+    },
+  })
+  console.log('Created admin:', admin.email)
+
+  // Create categories
+  const electronics = await prisma.category.create({
+    data: {
+      name: 'Electronics',
+      slug: 'electronics',
+      description: 'Latest gadgets, phones, tablets, and accessories',
+      image: 'https://images.unsplash.com/photo-1498049794561-7780e7231661?w=800',
+      type: 'STANDARD',
+      isActive: true,
+      position: 1,
+      adminId: admin.id,
     },
   })
 
-  console.log(`Created admin: ${admin.email}`)
-
-  const defaultBrands = [
-    { title: 'Toyota', description: 'Toyota Motor Corporation' },
-    { title: 'Honda', description: 'Honda Motor Co.' },
-    { title: 'BMW', description: 'Bayerische Motoren Werke' },
-    { title: 'Mercedes-Benz', description: 'Mercedes-Benz Group' },
-    { title: 'Ford', description: 'Ford Motor Company' },
-  ]
-
-  for (const brand of defaultBrands) {
-    await prisma.brand.upsert({
-      where: { title: brand.title },
-      update: {},
-      create: brand,
-    })
-  }
-
-  console.log(`Created ${defaultBrands.length} default brands`)
-
-  await prisma.siteConfig.upsert({
-    where: { id: 'default' },
-    update: {
-      defaultWhatsApp: '+233501234567',
-      businessName: 'E.A. First Class Autos',
-      businessEmail: 'info@eafirstclassautos.com',
-      businessAddress: 'Accra, Ghana',
-    },
-    create: {
-      id: 'default',
-      businessName: 'E.A. First Class Autos',
-      defaultWhatsApp: '+233501234567',
-      businessEmail: 'info@eafirstclassautos.com',
-      businessAddress: 'Accra, Ghana',
+  const homeAppliances = await prisma.category.create({
+    data: {
+      name: 'Home Appliances',
+      slug: 'home-appliances',
+      description: 'Kitchen appliances, home electronics, and household essentials',
+      image: 'https://images.unsplash.com/photo-1556911220-bff31c812dba?w=800',
+      type: 'STANDARD',
+      isActive: true,
+      position: 2,
+      adminId: admin.id,
     },
   })
 
-  console.log('Created default site config')
+  const clothingFabrics = await prisma.category.create({
+    data: {
+      name: 'Clothing & Fabrics',
+      slug: 'clothing-fabrics',
+      description: 'Quality clothing, fabrics, and fashion items',
+      image: 'https://images.unsplash.com/photo-1445205170230-053b83016050?w=800',
+      type: 'VARIANT',
+      isActive: true,
+      position: 3,
+      adminId: admin.id,
+    },
+  })
+  console.log('Created categories')
 
-  const brands = await prisma.brand.findMany()
+  // Create suppliers for Electronics
+  const electronicsSuppliers = await Promise.all([
+    prisma.supplier.create({
+      data: {
+        name: 'TechZone Ghana',
+        phone: '+233 20 123 4567',
+        email: 'info@techzone.com.gh',
+        address: 'Accra Mall, Accra',
+        adminId: admin.id,
+      },
+    }),
+    prisma.supplier.create({
+      data: {
+        name: 'Ghana Electronics Hub',
+        phone: '+233 30 234 5678',
+        email: 'sales@gehub.com.gh',
+        address: 'Kumasi Central Market, Kumasi',
+        adminId: admin.id,
+      },
+    }),
+    prisma.supplier.create({
+      data: {
+        name: 'Accra Gadgets Plus',
+        phone: '+233 50 345 6789',
+        email: 'contact@aggplus.com.gh',
+        address: 'Osu, Accra',
+        adminId: admin.id,
+      },
+    }),
+  ])
+  console.log('Created electronics suppliers')
 
-  const sampleCars = [
-    {
-      title: 'Toyota Camry 2022',
-      slug: 'toyota-camry-2022',
-      model: 'Camry',
-      year: 2022,
-      price: 25000,
-      isNegotiable: true,
-      condition: 'Local Used',
-      description: 'Well maintained sedan with low mileage. Single owner, full service history.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Toyota')!.id,
-    },
-    {
-      title: 'BMW X5 2023',
-      slug: 'bmw-x5-2023',
-      model: 'X5',
-      year: 2023,
-      price: 55000,
-      isNegotiable: false,
-      condition: 'Brand New',
-      description: 'Luxury SUV with premium features. M Sport package, panoramic roof.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'BMW')!.id,
-    },
-    {
-      title: 'Honda Civic 2021',
-      slug: 'honda-civic-2021',
-      model: 'Civic',
-      year: 2021,
-      price: 18000,
-      isNegotiable: true,
-      condition: 'Local Used',
-      description: 'Reliable and fuel-efficient compact car. Great condition.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Honda')!.id,
-    },
-    {
-      title: 'Mercedes-Benz C-Class 2023',
-      slug: 'mercedes-c-class-2023',
-      model: 'C-Class',
-      year: 2023,
-      price: 48000,
-      isNegotiable: false,
-      condition: 'Foreign Used',
-      description: 'Elegant sedan with advanced technology. AMG Line exterior.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Mercedes-Benz')!.id,
-    },
-    {
-      title: 'Ford F-150 2022',
-      slug: 'ford-f150-2022',
-      model: 'F-150',
-      year: 2022,
-      price: 35000,
-      isNegotiable: true,
-      condition: 'Foreign Used',
-      description: 'Powerful truck ready for any job. Extended cab, 4WD.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Ford')!.id,
-    },
-    {
-      title: 'Toyota RAV4 2023',
-      slug: 'toyota-rav4-2023',
-      model: 'RAV4',
-      year: 2023,
-      price: 32000,
-      isNegotiable: true,
-      condition: 'Brand New',
-      description: 'Versatile crossover SUV. Hybrid engine available.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Toyota')!.id,
-    },
-    {
-      title: 'Honda CR-V 2022',
-      slug: 'honda-cr-v-2022',
-      model: 'CR-V',
-      year: 2022,
-      price: 28000,
-      isNegotiable: true,
-      condition: 'Local Used',
-      description: 'Spacious and comfortable SUV. Perfect family car.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Honda')!.id,
-    },
-    {
-      title: 'BMW 3 Series 2023',
-      slug: 'bmw-3-series-2023',
-      model: '3 Series',
-      year: 2023,
-      price: 42000,
-      isNegotiable: false,
-      condition: 'Brand New',
-      description: 'The ultimate driving machine. Sport suspension, leather interior.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'BMW')!.id,
-    },
-    {
-      title: 'Mercedes-Benz GLE 2022',
-      slug: 'mercedes-gle-2022',
-      model: 'GLE',
-      year: 2022,
-      price: 62000,
-      isNegotiable: true,
-      condition: 'Foreign Used',
-      description: 'Premium luxury SUV. Burmester sound system, ambient lighting.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Mercedes-Benz')!.id,
-    },
-    {
-      title: 'Ford Mustang 2023',
-      slug: 'ford-mustang-2023',
-      model: 'Mustang',
-      year: 2023,
-      price: 38000,
-      isNegotiable: false,
-      condition: 'Brand New',
-      description: 'Iconic American muscle car. GT Performance Package.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Ford')!.id,
-    },
-    {
-      title: 'Toyota Corolla 2021',
-      slug: 'toyota-corolla-2021',
-      model: 'Corolla',
-      year: 2021,
-      price: 16000,
-      isNegotiable: true,
-      condition: 'Local Used',
-      description: 'Compact and efficient. Perfect for daily commuting.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Toyota')!.id,
-    },
-    {
-      title: 'Honda Accord 2022',
-      slug: 'honda-accord-2022',
-      model: 'Accord',
-      year: 2022,
-      price: 27000,
-      isNegotiable: true,
-      condition: 'Foreign Used',
-      description: 'Midsize sedan with excellent reliability. Touring trim.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Honda')!.id,
-    },
-    {
-      title: 'BMW X3 2023',
-      slug: 'bmw-x3-2023',
-      model: 'X3',
-      year: 2023,
-      price: 46000,
-      isNegotiable: false,
-      condition: 'Brand New',
-      description: 'Compact luxury SUV. xDrive, premium package.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'BMW')!.id,
-    },
-    {
-      title: 'Ford Explorer 2022',
-      slug: 'ford-explorer-2022',
-      model: 'Explorer',
-      year: 2022,
-      price: 36000,
-      isNegotiable: true,
-      condition: 'Foreign Used',
-      description: 'Three-row SUV with plenty of space for the whole family.',
-      images: ['/placeholder-car.svg'],
-      brandId: brands.find((b) => b.title === 'Ford')!.id,
-    },
-  ]
+  // Create suppliers for Home Appliances
+  const homeSuppliers = await Promise.all([
+    prisma.supplier.create({
+      data: {
+        name: 'Home Essentials Ghana',
+        phone: '+233 24 456 7890',
+        email: 'orders@homeessentials.com.gh',
+        address: 'Takoradi, Western Region',
+        adminId: admin.id,
+      },
+    }),
+    prisma.supplier.create({
+      data: {
+        name: 'Kitchen Masters Ghana',
+        phone: '+233 32 567 8901',
+        email: 'info@kitchenmasters.com.gh',
+        address: 'Tema, Greater Accra',
+        adminId: admin.id,
+      },
+    }),
+  ])
+  console.log('Created home appliances suppliers')
 
-  for (const carData of sampleCars) {
-    await prisma.car.upsert({
-      where: { slug: carData.slug },
+  // Create suppliers for Clothing
+  const clothingSuppliers = await Promise.all([
+    prisma.supplier.create({
+      data: {
+        name: 'Textile Connect Ghana',
+        phone: '+233 20 678 9012',
+        email: 'bulk@textileconnect.com.gh',
+        address: 'Kumasi, Ashanti Region',
+        adminId: admin.id,
+      },
+    }),
+    prisma.supplier.create({
+      data: {
+        name: 'Fashion Forward Ghana',
+        phone: '+233 26 789 0123',
+        email: 'sales@fashionforward.com.gh',
+        address: 'Accra Central',
+        adminId: admin.id,
+      },
+    }),
+    prisma.supplier.create({
+      data: {
+        name: 'Premium Fabrics Ltd',
+        phone: '+233 28 890 1234',
+        email: 'info@premiumfabrics.com.gh',
+        address: 'Cape Coast, Central Region',
+        adminId: admin.id,
+      },
+    }),
+  ])
+  console.log('Created clothing suppliers')
+
+  // Create Electronics products
+  const electronicsProducts = await Promise.all([
+    prisma.product.create({
+      data: {
+        name: 'Samsung Galaxy A15',
+        slug: 'samsung-galaxy-a15',
+        brand: 'Samsung',
+        description: '6.5" display, 128GB storage, 50MP camera, 5000mAh battery. Perfect for everyday use with excellent camera quality.',
+        price: 3499,
+        stock: 25,
+        isActive: true,
+        supplierId: electronicsSuppliers[0].id,
+        categoryId: electronics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1610945415295-d9bbf067e59c?w=800', position: 1 },
+            { url: 'https://images.unsplash.com/photo-1592899677977-9c10ca588bbd?w=800', position: 2 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Black', extraPrice: 0, stock: 25 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'iPhone 13 Refurbished',
+        slug: 'iphone-13-refurbished',
+        brand: 'Apple',
+        description: 'Certified refurbished iPhone 13, 128GB, excellent condition with 6-month warranty.',
+        price: 5999,
+        stock: 12,
+        isActive: true,
+        supplierId: electronicsSuppliers[1].id,
+        categoryId: electronics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1592750475338-74b7b21085ab?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Midnight Blue', extraPrice: 0, stock: 12 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Tecno Spark 10C',
+        slug: 'tecno-spark-10c',
+        brand: 'Tecno',
+        description: '6.6" HD+ display, 64GB storage, 5000mAh battery, side fingerprint. Budget-friendly smartphone.',
+        price: 1499,
+        stock: 40,
+        isActive: true,
+        supplierId: electronicsSuppliers[2].id,
+        categoryId: electronics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1511707171634-5f897ff02aa9?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Ocean Blue', extraPrice: 0, stock: 40 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Infinix Hot 30i',
+        slug: 'infinix-hot-30i',
+        brand: 'Infinix',
+        description: '6.6" display, 128GB, 50MP main camera, 5000mAh battery. Great value for money.',
+        price: 1799,
+        stock: 35,
+        isActive: true,
+        supplierId: electronicsSuppliers[0].id,
+        categoryId: electronics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Diamond White', extraPrice: 0, stock: 35 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'JBL Flip 6 Speaker',
+        slug: 'jbl-flip-6-speaker',
+        brand: 'JBL',
+        description: 'Portable Bluetooth speaker with powerful bass, 12 hours battery life, waterproof design.',
+        price: 899,
+        stock: 30,
+        isActive: true,
+        supplierId: electronicsSuppliers[1].id,
+        categoryId: electronics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1608043152269-423dbba4e7e1?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Black', extraPrice: 0, stock: 30 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Sony WH-1000XM5 Headphones',
+        slug: 'sony-wh-1000xm5',
+        brand: 'Sony',
+        description: 'Premium noise-canceling headphones, 30-hour battery, multipoint connection.',
+        price: 3499,
+        stock: 15,
+        isActive: true,
+        supplierId: electronicsSuppliers[2].id,
+        categoryId: electronics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1618366712010-f4ae9c647dcb?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Silver', extraPrice: 0, stock: 15 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Samsung Galaxy Tab A8',
+        slug: 'samsung-galaxy-tab-a8',
+        brand: 'Samsung',
+        description: '10.5" tablet, 64GB storage, perfect for entertainment and light work.',
+        price: 2499,
+        stock: 20,
+        isActive: true,
+        supplierId: electronicsSuppliers[0].id,
+        categoryId: electronics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1561154464-82e9adf32764?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Gray', extraPrice: 0, stock: 20 }],
+        },
+      },
+    }),
+  ])
+  console.log('Created electronics products')
+
+  // Create Home Appliances products
+  const homeProducts = await Promise.all([
+    prisma.product.create({
+      data: {
+        name: 'Hisense 50" Smart TV',
+        slug: 'hisense-50-smart-tv',
+        brand: 'Hisense',
+        description: '50" Full HD Smart TV, built-in WiFi, Netflix, YouTube pre-installed. Crystal clear picture quality.',
+        price: 4999,
+        stock: 10,
+        isActive: true,
+        supplierId: homeSuppliers[0].id,
+        categoryId: homeAppliances.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1593359677879-a4bb92f829d1?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Black', extraPrice: 0, stock: 10 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'LG 1.5 Ton AC',
+        slug: 'lg-1-5-ton-ac',
+        brand: 'LG',
+        description: '1.5 Ton split AC, inverter technology, energy efficient, cool and comfortable.',
+        price: 7999,
+        stock: 8,
+        isActive: true,
+        supplierId: homeSuppliers[1].id,
+        categoryId: homeAppliances.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1631545806609-28b573d1bc5b?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'White', extraPrice: 0, stock: 8 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Samsung 8kg Washing Machine',
+        slug: 'samsung-8kg-washing-machine',
+        brand: 'Samsung',
+        description: '8kg front load washing machine, multiple wash programs, eco-friendly.',
+        price: 5499,
+        stock: 12,
+        isActive: true,
+        supplierId: homeSuppliers[0].id,
+        categoryId: homeAppliances.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1556911220-bff31c812dba?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Silver', extraPrice: 0, stock: 12 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Scanfrost 3-Door Fridge',
+        slug: 'scanfrost-3-door-fridge',
+        brand: 'Scanfrost',
+        description: '450L side-by-side refrigerator, no-frost, energy efficient, built-in ice maker.',
+        price: 6999,
+        stock: 6,
+        isActive: true,
+        supplierId: homeSuppliers[1].id,
+        categoryId: homeAppliances.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1584568694244-14fbdf83bd30?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Stainless Steel', extraPrice: 0, stock: 6 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Microwave Oven 30L',
+        slug: 'microwave-oven-30l',
+        brand: 'Panasonic',
+        description: '30L microwave oven, multiple power levels, defrost function, timer.',
+        price: 1299,
+        stock: 25,
+        isActive: true,
+        supplierId: homeSuppliers[0].id,
+        categoryId: homeAppliances.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1574269909862-7e1d70bb8078?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'White', extraPrice: 0, stock: 25 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Electric Kettle 1.8L',
+        slug: 'electric-kettle-1-8l',
+        brand: 'Midea',
+        description: '1.8L electric kettle, fast boil, auto shut-off, stainless steel body.',
+        price: 399,
+        stock: 50,
+        isActive: true,
+        supplierId: homeSuppliers[1].id,
+        categoryId: homeAppliances.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'Silver', extraPrice: 0, stock: 50 }],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Standing Fan 18"',
+        slug: 'standing-fan-18',
+        brand: 'Nikano',
+        description: '18" oscillating standing fan, 3 speeds, remote control, quiet operation.',
+        price: 599,
+        stock: 35,
+        isActive: true,
+        supplierId: homeSuppliers[0].id,
+        categoryId: homeAppliances.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1584622650111-993a426fbf0a?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [{ size: 'Default', color: 'White', extraPrice: 0, stock: 35 }],
+        },
+      },
+    }),
+  ])
+  console.log('Created home appliances products')
+
+  // Create Clothing products with variants
+  const clothingProducts = await Promise.all([
+    prisma.product.create({
+      data: {
+        name: 'African Print Dress',
+        slug: 'african-print-dress',
+        brand: 'Ankara Queen',
+        description: 'Beautiful handcrafted African print dress, vibrant colors, perfect for special occasions.',
+        price: 899,
+        stock: 20,
+        isActive: true,
+        supplierId: clothingSuppliers[0].id,
+        categoryId: clothingFabrics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1594938298603-c8148c4dae35?w=800', position: 1 },
+            { url: 'https://images.unsplash.com/photo-1572804013309-59a88b7e92f1?w=800', position: 2 },
+          ],
+        },
+        variants: {
+          create: [
+            { size: 'S', color: 'Blue Print', extraPrice: 0, stock: 5 },
+            { size: 'M', color: 'Blue Print', extraPrice: 0, stock: 5 },
+            { size: 'L', color: 'Blue Print', extraPrice: 0, stock: 5 },
+            { size: 'XL', color: 'Blue Print', extraPrice: 0, stock: 5 },
+          ],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Men\'s Kente Shirt',
+        slug: 'mens-kente-shirt',
+        brand: 'Kente Kings',
+        description: 'Premium quality Kente patterned shirt, comfortable cotton blend, traditional yet modern.',
+        price: 699,
+        stock: 25,
+        isActive: true,
+        supplierId: clothingSuppliers[1].id,
+        categoryId: clothingFabrics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1602810318383-e386cc2a3ccf?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [
+            { size: 'S', color: 'Gold/Yellow', extraPrice: 0, stock: 5 },
+            { size: 'M', color: 'Gold/Yellow', extraPrice: 0, stock: 6 },
+            { size: 'L', color: 'Gold/Yellow', extraPrice: 0, stock: 7 },
+            { size: 'XL', color: 'Gold/Yellow', extraPrice: 0, stock: 4 },
+            { size: 'XXL', color: 'Gold/Yellow', extraPrice: 0, stock: 3 },
+          ],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Women\'s Palazzo Pants',
+        slug: 'womens-palazzo-pants',
+        brand: ' Faso Mode',
+        description: 'Elegant wide-leg palazzo pants, high waist, flowy fit. Perfect for office and casual wear.',
+        price: 499,
+        stock: 30,
+        isActive: true,
+        supplierId: clothingSuppliers[2].id,
+        categoryId: clothingFabrics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1594633312681-425c7b97ccd1?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [
+            { size: 'S', color: 'Black', extraPrice: 0, stock: 8 },
+            { size: 'M', color: 'Black', extraPrice: 0, stock: 8 },
+            { size: 'L', color: 'Black', extraPrice: 0, stock: 7 },
+            { size: 'XL', color: 'Black', extraPrice: 0, stock: 7 },
+          ],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'African Wax Fabric (6 Yards)',
+        slug: 'african-wax-fabric',
+        brand: 'Vlisco',
+        description: 'Premium quality African wax print fabric, 6 yards per piece, vibrant colors that last.',
+        price: 799,
+        stock: 40,
+        isActive: true,
+        supplierId: clothingSuppliers[0].id,
+        categoryId: clothingFabrics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1558171813-4c088753af8f?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [
+            { size: '6 Yards', color: 'Red/Orange', extraPrice: 0, stock: 10 },
+            { size: '6 Yards', color: 'Blue/Green', extraPrice: 0, stock: 10 },
+            { size: '6 Yards', color: 'Purple/Pink', extraPrice: 0, stock: 10 },
+            { size: '6 Yards', color: 'Yellow/Gold', extraPrice: 0, stock: 10 },
+          ],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Men\'s Agbada Outfit',
+        slug: 'mens-agbada-outfit',
+        brand: 'Royal Wears',
+        description: 'Traditional Agbada outfit, complete with shirt and hat, for special occasions.',
+        price: 1499,
+        stock: 15,
+        isActive: true,
+        supplierId: clothingSuppliers[1].id,
+        categoryId: clothingFabrics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [
+            { size: 'M', color: 'White', extraPrice: 0, stock: 3 },
+            { size: 'L', color: 'White', extraPrice: 0, stock: 4 },
+            { size: 'XL', color: 'White', extraPrice: 0, stock: 4 },
+            { size: 'XXL', color: 'White', extraPrice: 0, stock: 4 },
+          ],
+        },
+      },
+    }),
+    prisma.product.create({
+      data: {
+        name: 'Women\'s Head Tie (Gele)',
+        slug: 'womens-head-tie',
+        brand: 'Scarf World',
+        description: 'Premium quality head tie (Gele), large size for various styles, smooth finish.',
+        price: 249,
+        stock: 60,
+        isActive: true,
+        supplierId: clothingSuppliers[2].id,
+        categoryId: clothingFabrics.id,
+        adminId: admin.id,
+        images: {
+          create: [
+            { url: 'https://images.unsplash.com/photo-1601924994987-69e26d50dc26?w=800', position: 1 },
+          ],
+        },
+        variants: {
+          create: [
+            { size: 'One Size', color: 'Multi-Pattern 1', extraPrice: 0, stock: 15 },
+            { size: 'One Size', color: 'Multi-Pattern 2', extraPrice: 0, stock: 15 },
+            { size: 'One Size', color: 'Solid Blue', extraPrice: 0, stock: 15 },
+            { size: 'One Size', color: 'Solid Red', extraPrice: 0, stock: 15 },
+          ],
+        },
+      },
+    }),
+  ])
+  console.log('Created clothing products')
+
+  // Create banners
+  const banners = await Promise.all([
+    prisma.banner.create({
+      data: {
+        title: 'Summer Sale - Up to 30% Off',
+        image: 'https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=1200',
+        description: 'Shop the best deals on electronics, home appliances, and fashion',
+        link: '/products',
+        isActive: true,
+        position: 1,
+      },
+    }),
+    prisma.banner.create({
+      data: {
+        title: 'New Arrivals - Fashion Collection',
+        image: 'https://images.unsplash.com/photo-1445205170230-053b83016050?w=1200',
+        description: 'Discover the latest African prints and contemporary fashion',
+        link: '/category/clothing-fabrics',
+        isActive: true,
+        position: 2,
+      },
+    }),
+    prisma.banner.create({
+      data: {
+        title: 'Free Delivery on Orders Over ₵500',
+        image: 'https://images.unsplash.com/photo-1556742049-0cfed4f6a45d?w=1200',
+        description: 'Shop now and enjoy free delivery across Ghana',
+        link: '/products',
+        isActive: true,
+        position: 3,
+      },
+    }),
+  ])
+  console.log('Created banners')
+
+  // Create site config
+  const siteConfigs = await Promise.all([
+    prisma.siteConfig.upsert({
+      where: { key: 'businessName' },
       update: {},
-      create: carData,
-    })
-  }
+      create: { key: 'businessName', value: 'First Class Autos & Electronics' },
+    }),
+    prisma.siteConfig.upsert({
+      where: { key: 'businessPhone' },
+      update: {},
+      create: { key: 'businessPhone', value: '+233 50 123 4567' },
+    }),
+    prisma.siteConfig.upsert({
+      where: { key: 'businessEmail' },
+      update: {},
+      create: { key: 'businessEmail', value: 'info@firstclassautos.com' },
+    }),
+    prisma.siteConfig.upsert({
+      where: { key: 'businessAddress' },
+      update: {},
+      create: { key: 'businessAddress', value: 'Accra, Ghana' },
+    }),
+    prisma.siteConfig.upsert({
+      where: { key: 'whatsappNumber' },
+      update: {},
+      create: { key: 'whatsappNumber', value: '+233 20 123 4567' },
+    }),
+  ])
+  console.log('Created site config')
 
-  console.log(`Created ${sampleCars.length} sample cars`)
+  console.log('Seed completed successfully!')
+  console.log(`Summary:
+    - 1 Admin
+    - 3 Categories
+    - 8 Suppliers (3 electronics, 2 home, 3 clothing)
+    - ${electronicsProducts.length} Electronics products
+    - ${homeProducts.length} Home Appliances products
+    - ${clothingProducts.length} Clothing products
+    - ${banners.length} Banners
+    - ${siteConfigs.length} Site Config entries`)
 }
 
 main()
-  .then(async () => {
-    await prisma.$disconnect()
-  })
-  .catch(async (e) => {
+  .catch((e) => {
     console.error(e)
-    await prisma.$disconnect()
     process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
   })

--- a/docs/superpowers/specs/2026-05-09-carthouse-gh-design.md
+++ b/docs/superpowers/specs/2026-05-09-carthouse-gh-design.md
@@ -402,11 +402,20 @@ Form fields:
 
 ---
 
+### 5.3 Delivery Fee
+
+- Delivery fee is **NOT calculated at checkout**
+- Customer places order, payment is collected (Paystack or COD)
+- After order, you **call customer** to inform delivery fee and arrange delivery
+- This keeps things flexible for your operation
+
+---
+
 ## 15. Open Questions
 
-- [ ] Paystack account setup (test vs live mode)?
-- [ ] Delivery fee structure (flat fee, zone-based, free over X)?
-- [ ] Product images source — who provides?
+- [x] Paystack account setup — **Live mode**
+- [x] Delivery fee structure — **Handled manually via phone call**
+- [x] Product images source — **Admin uploads via UploadThing**
 - [ ] Social media integration (auto-post new products)?
 - [ ] Review/rating system for products?
 - [ ] Newsletter signup?

--- a/docs/superpowers/specs/2026-05-09-carthouse-gh-design.md
+++ b/docs/superpowers/specs/2026-05-09-carthouse-gh-design.md
@@ -1,0 +1,412 @@
+# CartHouse GH — E-Commerce Platform Design
+
+**Date:** 2026-05-09
+**Status:** Draft
+**Purpose:** Complete refactor from car dealership to general e-commerce store
+
+---
+
+## 1. Overview
+
+CartHouse GH is a general e-commerce platform selling electronics, home appliances, and clothing/fabrics. Key differentiator: suppliers handle delivery directly to customers. Platform supports both authenticated and guest checkout, with Paystack and Cash on Delivery (COD) as payment options.
+
+---
+
+## 2. Product Model
+
+### 2.1 Core Fields
+
+| Field | Type | Description |
+|---|---|---|
+| id | cuid | Primary key |
+| name | String | Product name |
+| slug | String | URL-friendly identifier (unique) |
+| description | Text | Product description |
+| price | Float | Selling price (includes margin) |
+| condition | String | Optional: "New", "Used", "Refurbished" |
+| stock | Int | Available quantity (managed manually) |
+| isAvailable | Boolean | Visible on site |
+| isDeleted | Boolean | Soft delete |
+| media | String[] | Array of image/video URLs |
+| videoUrl | String? | Optional product video |
+| createdAt | DateTime | Auto |
+| updatedAt | DateTime | Auto |
+
+### 2.2 Product Variants (Clothing)
+
+| Field | Type | Description |
+|---|---|---|
+| variantId | String | SKU-style identifier |
+| size | Enum | S, M, L, XL, XXL |
+| color | String | Color name |
+| stock | Int | Stock per variant |
+
+**Note:** Gadgets/electronics use single variant (no size/color).
+
+### 2.3 Product-Supplier Link
+
+| Field | Type | Description |
+|---|---|---|
+| supplierId | String | FK to Supplier |
+| supplierCost | Float? | Cost price from supplier (internal) |
+
+---
+
+## 3. Category Structure
+
+Top-level categories with optional sub-categories (brands):
+
+```
+Phone Accessories
+├── Airpods
+├── Chargers
+├── Cables
+├── Cases
+└── Power Banks
+
+Computing
+├── Mifi Devices
+├── Keyboard & Mouse
+├── Laptop Chargers
+└── Laptop Stands
+
+Kitchen Appliances
+├── Blenders
+├── Rice Cookers
+├── Electric Cookers
+└── Microwaves
+
+Home Appliances
+├── Air Conditioners (AC)
+├── Televisions (TV)
+├── Fans
+├── Irons
+└── Extension Boards
+
+Clothing & Fabrics
+├── Men's Wear
+├── Women's Wear
+├── Children's Wear
+└── Fabrics
+```
+
+---
+
+## 4. Supplier Model
+
+Admin-only. Never exposed to customers.
+
+| Field | Type | Description |
+|---|---|---|
+| id | cuid | Primary key |
+| name | String | Supplier name |
+| phone | String | WhatsApp number |
+| email | String? | Contact email |
+| address | String? | Business address |
+| deliveryZones | String[] | Areas they deliver to |
+| deliveryFee | Float? | Default delivery fee |
+| notes | String? | Internal notes |
+| products | Product[] | Linked products |
+
+### 4.1 Supplier-Order Flow
+
+1. Order created in admin
+2. Admin clicks "Send to Supplier" button
+3. WhatsApp opens with pre-filled message:
+   ```
+   New Order #ORD-XXXX
+
+   Customer: [Name]
+   Phone: [Phone]
+   Address: [Address]
+
+   Product: [Product Name]
+   Quantity: [Qty]
+   Size: [Size if applicable]
+   Color: [Color if applicable]
+
+   Payment: [Paystack / COD]
+   Amount Paid: [GH₵ Amount]
+
+   Please deliver to customer. Thank you!
+   ```
+
+---
+
+## 5. Payment Methods
+
+### 5.1 Paystack (Full Prepayment)
+
+- Customer enters card details
+- Payment captured immediately
+- Order marked as "Paid"
+- Admin notified via dashboard/email
+
+### 5.2 Cash on Delivery (COD)
+
+- Order created with "COD Pending" status
+- Supplier notified with COD flag
+- Payment collected on delivery
+- Status updated to "Delivered + Paid"
+
+---
+
+## 6. Checkout Flow
+
+### 6.1 Guest Checkout (Primary)
+
+**Step 1: Cart Review**
+- View items, quantities, subtotal
+- Update or remove items
+
+**Step 2: Delivery Information**
+- Full name (required)
+- Phone number (required)
+- Region/Area (dropdown)
+- Detailed address (required)
+- Delivery instructions (optional)
+
+**Step 3: Payment Method**
+- Paystack (default first)
+- Cash on Delivery
+
+**Step 4: Order Confirmation**
+- Order number generated
+- Summary displayed
+- WhatsApp tracking link provided
+- Email confirmation (optional)
+
+### 6.2 Account Checkout (Optional)
+
+- Customer can create account to save:
+  - Delivery addresses
+  - Order history
+  - Wishlist
+- Account is **never required** for checkout
+
+---
+
+## 7. Order Model
+
+| Field | Type | Description |
+|---|---|---|
+| id | cuid | Primary key |
+| orderNumber | String | Human-readable: ORD-XXXX |
+| customerName | String | From checkout |
+| customerPhone | String | From checkout |
+| customerAddress | String | From checkout |
+| paymentMethod | Enum | PAYSTACK, COD |
+| paymentStatus | Enum | PENDING, PAID, DELIVERED_PAID |
+| orderStatus | Enum | PENDING, CONFIRMED, OUT_FOR_DELIVERY, DELIVERED, CANCELLED |
+| totalAmount | Float | Order total |
+| deliveryFee | Float | Included in total |
+| items | OrderItem[] | Array of products ordered |
+| notes | String? | Internal notes |
+| createdAt | DateTime | Auto |
+
+### 7.1 OrderItem
+
+| Field | Type | Description |
+|---|---|---|
+| productId | String | FK to Product |
+| productName | String | Snapshot at order time |
+| quantity | Int | Ordered quantity |
+| price | Float | Price at order time |
+| size | String? | For clothing |
+| color | String? | For clothing |
+| supplierId | String | FK to Supplier |
+
+---
+
+## 8. Site Structure
+
+### 8.1 Customer Pages
+
+| Route | Description |
+|---|---|
+| `/` | Homepage — featured products, categories, banner carousel |
+| `/products` | All products with filters (category, price range) |
+| `/products/[slug]` | Product detail — images, video, sizes, add to cart |
+| `/category/[slug]` | Category listing with brand filter |
+| `/cart` | Shopping cart |
+| `/checkout` | Guest checkout form |
+| `/checkout/account` | Account checkout (logged in users) |
+| `/order/[id]` | Order confirmation / tracking |
+| `/account` | Customer account — orders, addresses (optional) |
+
+### 8.2 Admin Pages
+
+| Route | Description |
+|---|---|
+| `/admin` | Dashboard — orders overview, recent activity |
+| `/admin/products` | Product list, add/edit/delete |
+| `/admin/products/new` | Add product form |
+| `/admin/products/[id]` | Edit product |
+| `/admin/categories` | Manage categories and brands |
+| `/admin/suppliers` | Manage suppliers |
+| `/admin/orders` | Order list with status filters |
+| `/admin/orders/[id]` | Order detail + supplier actions |
+| `/admin/banners` | Homepage banner management |
+| `/admin/settings` | Site config, business info |
+
+---
+
+## 9. Homepage Layout
+
+### 9.1 Sections (Top to Bottom)
+
+1. **Navigation Bar**
+   - Logo (CartHouse GH)
+   - Category links
+   - Search bar
+   - Cart icon with count
+
+2. **Hero Banner Carousel**
+   - Rotating promotional banners
+   - Auto-play with manual navigation
+
+3. **Category Grid**
+   - Visual cards for each category
+   - Icon/image + category name
+
+4. **Featured Products**
+   - 8-12 handpicked products
+   - "Add to Cart" button
+
+5. **Flash Sales / Deals** (optional)
+   - Countdown timer
+   - Discount badges
+
+6. **New Arrivals**
+   - Recently added products
+
+7. **Footer**
+   - Contact info
+   - Social links
+   - Payment icons
+
+---
+
+## 10. Product Detail Page
+
+- Image gallery (main + thumbnails, video support)
+- Product name, price, description
+- **For clothing:** Size selector, color selector, stock per variant
+- **For gadgets:** Add to cart directly
+- Quantity selector
+- Add to Cart button
+- WhatsApp inquiry button (alternative to checkout)
+- Related products section
+
+---
+
+## 11. Admin Dashboard
+
+### 11.1 Product Management
+
+Form fields:
+- Name, Slug (auto-generated, editable)
+- Category (dropdown)
+- Brand (optional)
+- Description (rich text)
+- Price (selling price)
+- Supplier (dropdown)
+- Stock quantity
+- Media upload (images + video)
+- Size/Color variants (for clothing)
+- Availability toggle
+
+### 11.2 Supplier Management
+
+Form fields:
+- Name
+- WhatsApp number
+- Email
+- Address
+- Delivery zones
+- Notes
+
+### 11.3 Order Management
+
+- List view with columns: Order #, Customer, Items, Total, Status, Date
+- Filters: All, Pending, COD, Delivered
+- Individual order view:
+  - Customer info
+  - Items ordered
+  - Payment status
+  - **"Send to Supplier"** button → WhatsApp
+  - Status update dropdown
+
+---
+
+## 12. Data Migration
+
+### 12.1 Remove (Car dealership content)
+
+- `Car` model → Delete
+- `Brand` model → Delete
+- `WhatsappClick` model → Delete
+- Homepage car listings → Remove
+- Car-related components → Remove
+
+### 12.2 Retain (Framework)
+
+- User/Auth system (Admin accounts)
+- UI components (button, card, input, etc.)
+- Design tokens (colors, typography)
+- Prisma schema structure
+- Next.js app structure
+- Email templates
+
+### 12.3 Add (New models)
+
+- Product (replaces Car)
+- Category (replaces Brand)
+- Supplier (new)
+- Order (new)
+- OrderItem (new)
+- Banner (existing, keep)
+
+---
+
+## 13. Technical Stack
+
+- **Frontend:** Next.js (App Router)
+- **Styling:** Tailwind CSS
+- **Database:** PostgreSQL (Neon)
+- **ORM:** Prisma
+- **Auth:** Admin auth (JWT), Customer accounts optional
+- **Payments:** Paystack API
+- **Media:** Cloudinary / UploadThing
+- **Email:** React Email
+- **State:** React Context / Zustand
+- **Forms:** React Hook Form + Zod
+
+---
+
+## 14. Implementation Order
+
+1. **Schema Refactor** — Drop Car/Brand, add Product/Category/Supplier/Order
+2. **Admin Setup** — Auth, layout, navigation
+3. **Category & Supplier Management** — CRUD in admin
+4. **Product Management** — CRUD with media upload, variants
+5. **Customer Homepage** — Categories, featured products, banners
+6. **Product Listing & Detail** — Filters, image gallery, variants
+7. **Cart System** — Add/remove, persist
+8. **Checkout Flow** — Guest form, payment method selection
+9. **Paystack Integration** — Payment capture
+10. **Order Management** — Admin list, detail, WhatsApp action
+11. **Order Confirmation** — Customer view, tracking link
+12. **Email Notifications** — Order confirmations
+13. **Polish** — Animations, loading states, error handling
+
+---
+
+## 15. Open Questions
+
+- [ ] Paystack account setup (test vs live mode)?
+- [ ] Delivery fee structure (flat fee, zone-based, free over X)?
+- [ ] Product images source — who provides?
+- [ ] Social media integration (auto-post new products)?
+- [ ] Review/rating system for products?
+- [ ] Newsletter signup?


### PR DESCRIPTION
## Summary
- Migrated Prisma schema from car dealership to e-commerce models
- Removed Car, Brand models; added Category, Supplier, Product, ProductVariant, ProductImage, Customer, Order, OrderItem, CartItem, WishlistItem
- Added enums: CategoryType, PaymentMethod, PaymentStatus, OrderStatus
- Created comprehensive seed script with 3 categories, 8 suppliers, 20 products (7 electronics, 7 home appliances, 6 clothing), 3 banners, and site config

## Test Plan
- [x] `pnpm db:push` succeeds (ran with --accept-data-loss for existing data)
- [x] `pnpm db:seed` runs without errors
- [x] 3 categories created with correct types (STANDARD/VARIANT)
- [x] Clothing products have size/color variants; gadgets have single default variant
- [x] 3 hero banners created for homepage

Closes #57