### PR TITLE
1-admin-categories-suppliers — Categories and Suppliers CRUD

### DIFF
--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -1,9 +1,7 @@
 /** @type {import('next').NextConfig} */
 
 module.exports = {
-   turbopack: {
-      root: 'D:\\Damz Proj\\Auto\\next-prisma-tailwind-ecommerce',
-   },
+   outputFileTracingExcludes: ['node_modules/**'],
    allowedDevOrigins: ['192.168.100.19'],
    images: {
       remotePatterns: [

--- a/apps/admin/prisma/schema.prisma
+++ b/apps/admin/prisma/schema.prisma
@@ -65,6 +65,58 @@ model Banner {
   updatedAt DateTime @updatedAt
 }
 
+model Category {
+  id          String     @id @default(cuid())
+  name        String
+  slug        String     @unique
+  description String?    @db.Text
+  image       String?
+  type        String     @default("STANDARD")
+  position    Int        @default(0)
+  isActive   Boolean    @default(true)
+
+  products  Product[]
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  @@index([slug])
+}
+
+model Supplier {
+  id        String   @id @default(cuid())
+  name      String
+  phone     String?
+  email     String?
+  address   String?
+
+  products Product[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Product {
+  id          String   @id @default(cuid())
+  name        String
+  slug        String   @unique
+  description String?  @db.Text
+  price       Float    @default(0)
+  images      String[]
+  stock       Int      @default(0)
+  sku         String?
+
+  category   Category? @relation(fields: [categoryId], references: [id])
+  categoryId String?
+  supplier   Supplier? @relation(fields: [supplierId], references: [id])
+  supplierId String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([slug])
+  @@index([categoryId])
+  @@index([supplierId])
+}
+
 model SiteConfig {
   id              String  @id @default(cuid())
   defaultWhatsApp String?

--- a/apps/admin/src/app/(dashboard)/(routes)/categories/[categoryId]/components/category-form.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/categories/[categoryId]/components/category-form.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { toast } from 'react-hot-toast'
+import { CategoryImageUpload } from './category-image-upload'
+
+export function CategoryForm({ initialData }: { initialData?: any }) {
+   const router = useRouter()
+   const [loading, setLoading] = useState(false)
+   const [data, setData] = useState({
+      name: initialData?.name || '',
+      description: initialData?.description || '',
+      image: initialData?.image || '',
+      type: initialData?.type || 'STANDARD',
+      position: initialData?.position?.toString() || '0',
+      isActive: initialData?.isActive ?? true,
+   })
+
+   const handleSubmit = async (e: React.FormEvent) => {
+      e.preventDefault()
+      setLoading(true)
+
+      try {
+         const payload = {
+            ...data,
+            position: parseInt(data.position) || 0,
+         }
+
+         const method = initialData ? 'PATCH' : 'POST'
+         const url = initialData ? `/api/categories/${initialData.id}` : '/api/categories'
+
+         const res = await fetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+         })
+
+         if (!res.ok) throw new Error('Failed to save')
+
+         toast.success(initialData ? 'Category updated!' : 'Category created!')
+         router.push('/categories')
+         router.refresh()
+      } catch (error) {
+         toast.error('Something went wrong')
+      } finally {
+         setLoading(false)
+      }
+   }
+
+   return (
+      <form onSubmit={handleSubmit} className="space-y-6">
+         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+               <Label>Name *</Label>
+               <Input
+                  value={data.name}
+                  onChange={(e) => setData({ ...data, name: e.target.value })}
+                  required
+               />
+            </div>
+            <div className="space-y-2">
+               <Label>Type</Label>
+               <Select value={data.type} onValueChange={(value) => setData({ ...data, type: value })}>
+                  <SelectTrigger>
+                     <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                     <SelectItem value="STANDARD">Standard</SelectItem>
+                     <SelectItem value="VARIANT">Variant</SelectItem>
+                  </SelectContent>
+               </Select>
+            </div>
+            <div className="space-y-2">
+               <Label>Position</Label>
+               <Input
+                  type="number"
+                  value={data.position}
+                  onChange={(e) => setData({ ...data, position: e.target.value })}
+               />
+            </div>
+            <div className="flex items-center gap-2 pt-6">
+               <Checkbox
+                  id="isActive"
+                  checked={data.isActive}
+                  onCheckedChange={(checked) => setData({ ...data, isActive: !!checked })}
+               />
+               <Label htmlFor="isActive">Active</Label>
+            </div>
+         </div>
+
+         <div className="space-y-2">
+            <Label>Description</Label>
+            <Textarea
+               value={data.description}
+               onChange={(e) => setData({ ...data, description: e.target.value })}
+               rows={4}
+            />
+         </div>
+
+         <div className="space-y-2">
+            <Label>Image</Label>
+            <CategoryImageUpload
+               images={data.image ? [data.image] : []}
+               onChange={(urls) => setData({ ...data, image: urls[0] || '' })}
+            />
+         </div>
+
+         <div className="flex gap-4">
+            <Button type="submit" disabled={loading}>
+               {loading ? 'Saving...' : initialData ? 'Update Category' : 'Create Category'}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+               Cancel
+            </Button>
+         </div>
+      </form>
+   )
+}

--- a/apps/admin/src/app/(dashboard)/(routes)/categories/[categoryId]/components/category-image-upload.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/categories/[categoryId]/components/category-image-upload.tsx
@@ -3,18 +3,18 @@
 import { useState } from 'react'
 import { UploadButton } from '@/components/utils/upload-button'
 
-interface ImageUploadProps {
+interface CategoryImageUploadProps {
    images: string[]
    onChange: (value: string[]) => void
    disabled?: boolean
 }
 
-export function ImageUpload({ images, onChange, disabled }: ImageUploadProps) {
+export function CategoryImageUpload({ images, onChange, disabled }: CategoryImageUploadProps) {
    return (
       <div className="space-y-4">
          <div className="flex flex-wrap gap-4">
             {images.map((url, index) => (
-               <div key={index} className="relative w-24 h-24">
+               <div key={index} className="relative w-32 h-32">
                   <img
                      src={url}
                      alt={`Image ${index + 1}`}
@@ -31,7 +31,7 @@ export function ImageUpload({ images, onChange, disabled }: ImageUploadProps) {
             ))}
          </div>
          <UploadButton
-            endpoint="carImage"
+            endpoint="categoryImage"
             onClientUploadComplete={(res) => {
                const urls = res.map((r) => r.url)
                onChange([...images, ...urls])

--- a/apps/admin/src/app/(dashboard)/(routes)/categories/[categoryId]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/categories/[categoryId]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from 'next/navigation'
+import prisma from '@/lib/prisma'
+import { Heading } from '@/components/ui/heading'
+import { Separator } from '@/components/ui/separator'
+import { CategoryForm } from './components/category-form'
+
+interface Props {
+   params: Promise<{ categoryId: string }>
+}
+
+export default async function CategoryPage(props: Props) {
+   const params = await props.params
+   const categoryId = params.categoryId
+
+   const category = categoryId === 'new'
+      ? null
+      : await prisma.category.findUnique({ where: { id: categoryId } })
+
+   if (categoryId !== 'new' && !category) {
+      notFound()
+   }
+
+   return (
+      <div className="container mx-auto py-6">
+         <Heading title={category ? 'Edit Category' : 'Add Category'} description={category ? 'Edit category details' : 'Add a new category'} />
+         <Separator className="my-6" />
+         <CategoryForm initialData={category} />
+      </div>
+   )
+}

--- a/apps/admin/src/app/(dashboard)/(routes)/categories/components/table.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/categories/components/table.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { DataTable } from '@/components/ui/data-table'
+import { ColumnDef } from '@tanstack/react-table'
+import { EditIcon, TrashIcon } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { toast } from 'react-hot-toast'
+import Image from 'next/image'
+
+interface CategoriesTableProps {
+   data: CategoryColumn[]
+}
+
+export const CategoriesTable: React.FC<CategoriesTableProps> = ({ data }) => {
+   return <DataTable searchKey="name" columns={columns} data={data} />
+}
+
+export type CategoryColumn = {
+   id: string
+   name: string
+   slug: string
+   description: string
+   image: string | null
+   type: string
+   position: number
+   isActive: boolean
+   productCount: number
+}
+
+function DeleteButton({ categoryId }: { categoryId: string }) {
+   const router = useRouter()
+   const [loading, setLoading] = useState(false)
+
+   const handleDelete = async () => {
+      if (!confirm('Are you sure you want to delete this category?')) return
+      setLoading(true)
+      try {
+         const res = await fetch(`/api/categories/${categoryId}`, { method: 'DELETE' })
+         if (!res.ok) throw new Error()
+         toast.success('Category deleted.')
+         router.refresh()
+      } catch {
+         toast.error('Failed to delete category.')
+      } finally {
+         setLoading(false)
+      }
+   }
+
+   return (
+      <Button size="icon" variant="outline" onClick={handleDelete} disabled={loading}>
+         <TrashIcon className="h-4" />
+      </Button>
+   )
+}
+
+function ToggleActiveButton({ categoryId, isActive }: { categoryId: string; isActive: boolean }) {
+   const router = useRouter()
+   const [loading, setLoading] = useState(false)
+
+   const handleToggle = async () => {
+      setLoading(true)
+      try {
+         const res = await fetch(`/api/categories/${categoryId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ isActive: !isActive }),
+         })
+         if (!res.ok) throw new Error()
+         toast.success(isActive ? 'Category deactivated.' : 'Category activated.')
+         router.refresh()
+      } catch {
+         toast.error('Failed to update status.')
+      } finally {
+         setLoading(false)
+      }
+   }
+
+   return (
+      <Button
+         size="icon"
+         variant="outline"
+         onClick={handleToggle}
+         disabled={loading}
+         title={isActive ? 'Deactivate' : 'Activate'}
+      >
+         <span className={`h-2 w-2 rounded-full ${isActive ? 'bg-green-500' : 'bg-gray-400'}`} />
+      </Button>
+   )
+}
+
+export const columns: ColumnDef<CategoryColumn>[] = [
+   {
+      accessorKey: 'image',
+      header: '',
+      cell: ({ row }) => {
+         const src = row.original.image
+         if (!src) return <div className="h-10 w-14 rounded bg-muted" />
+         return (
+            <div className="relative h-10 w-14 rounded overflow-hidden bg-muted">
+               <Image src={src} alt={row.original.name} fill className="object-cover" sizes="56px" />
+            </div>
+         )
+      },
+   },
+   {
+      accessorKey: 'name',
+      header: 'Name',
+   },
+   {
+      accessorKey: 'type',
+      header: 'Type',
+      cell: ({ row }) => (
+         <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700">
+            {row.original.type}
+         </span>
+      ),
+   },
+   {
+      accessorKey: 'position',
+      header: 'Position',
+   },
+   {
+      accessorKey: 'isActive',
+      header: 'Status',
+      cell: (props) => {
+         const active = props.cell.getValue() as boolean
+         return (
+            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+               active ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+            }`}>
+               {active ? 'Active' : 'Inactive'}
+            </span>
+         )
+      },
+   },
+   {
+      accessorKey: 'productCount',
+      header: 'Products',
+      cell: ({ row }) => (
+         <span className="text-sm">{row.original.productCount}</span>
+      ),
+   },
+   {
+      id: 'actions',
+      cell: ({ row }) => (
+         <div className="flex gap-1">
+            <Link href={`/categories/${row.original.id}`}>
+               <Button size="icon" variant="outline">
+                  <EditIcon className="h-4" />
+               </Button>
+            </Link>
+            <ToggleActiveButton categoryId={row.original.id} isActive={row.original.isActive} />
+            <DeleteButton categoryId={row.original.id} />
+         </div>
+      ),
+   },
+]

--- a/apps/admin/src/app/(dashboard)/(routes)/categories/loading.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/categories/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+   return <div className="py-6 animate-pulse"><div className="h-8 w-48 bg-muted rounded mb-4" /><div className="h-4 w-64 bg-muted rounded" /></div>
+}

--- a/apps/admin/src/app/(dashboard)/(routes)/categories/page.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/categories/page.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@/components/ui/button'
+import { Heading } from '@/components/ui/heading'
+import { Separator } from '@/components/ui/separator'
+import prisma from '@/lib/prisma'
+import { Plus } from 'lucide-react'
+import Link from 'next/link'
+
+import { CategoriesTable } from './components/table'
+import { CategoryColumn } from './components/table'
+
+export default async function CategoriesPage() {
+   const categories = await prisma.category.findMany({
+      include: { _count: { select: { products: true } } },
+      orderBy: [{ type: 'asc' }, { position: 'asc' }],
+   })
+
+   const formattedCategories: CategoryColumn[] = categories.map((cat) => ({
+      id: cat.id,
+      name: cat.name,
+      slug: cat.slug,
+      description: cat.description || '',
+      image: cat.image || null,
+      type: cat.type,
+      position: cat.position,
+      isActive: cat.isActive,
+      productCount: cat._count.products,
+   }))
+
+   return (
+      <div className="block space-y-4 my-6">
+         <div className="flex items-center justify-between">
+            <Heading
+               title={`Categories (${categories.length})`}
+               description="Manage product categories"
+            />
+            <Link href="/categories/new">
+               <Button>
+                  <Plus className="mr-2 h-4" /> Add New
+               </Button>
+            </Link>
+         </div>
+         <Separator />
+         {categories.length > 0 ? (
+            <CategoriesTable data={formattedCategories} />
+         ) : (
+            <div className="text-center py-10 text-neutral-500">
+               No categories yet. Add your first category to get started.
+            </div>
+         )}
+      </div>
+   )
+}

--- a/apps/admin/src/app/(dashboard)/(routes)/suppliers/[supplierId]/components/supplier-form.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/suppliers/[supplierId]/components/supplier-form.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { toast } from 'react-hot-toast'
+
+export function SupplierForm({ initialData }: { initialData?: any }) {
+   const router = useRouter()
+   const [loading, setLoading] = useState(false)
+   const [data, setData] = useState({
+      name: initialData?.name || '',
+      phone: initialData?.phone || '',
+      email: initialData?.email || '',
+      address: initialData?.address || '',
+   })
+
+   const handleSubmit = async (e: React.FormEvent) => {
+      e.preventDefault()
+      setLoading(true)
+
+      try {
+         const method = initialData ? 'PATCH' : 'POST'
+         const url = initialData ? `/api/suppliers/${initialData.id}` : '/api/suppliers'
+
+         const res = await fetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+         })
+
+         if (!res.ok) throw new Error('Failed to save')
+
+         toast.success(initialData ? 'Supplier updated!' : 'Supplier created!')
+         router.push('/suppliers')
+         router.refresh()
+      } catch (error) {
+         toast.error('Something went wrong')
+      } finally {
+         setLoading(false)
+      }
+   }
+
+   return (
+      <form onSubmit={handleSubmit} className="space-y-6">
+         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+               <Label>Name *</Label>
+               <Input
+                  value={data.name}
+                  onChange={(e) => setData({ ...data, name: e.target.value })}
+                  required
+               />
+            </div>
+            <div className="space-y-2">
+               <Label>Phone</Label>
+               <Input
+                  value={data.phone}
+                  onChange={(e) => setData({ ...data, phone: e.target.value })}
+               />
+            </div>
+            <div className="space-y-2">
+               <Label>Email</Label>
+               <Input
+                  type="email"
+                  value={data.email}
+                  onChange={(e) => setData({ ...data, email: e.target.value })}
+               />
+            </div>
+         </div>
+
+         <div className="space-y-2">
+            <Label>Address</Label>
+            <Textarea
+               value={data.address}
+               onChange={(e) => setData({ ...data, address: e.target.value })}
+               rows={3}
+            />
+         </div>
+
+         <div className="flex gap-4">
+            <Button type="submit" disabled={loading}>
+               {loading ? 'Saving...' : initialData ? 'Update Supplier' : 'Create Supplier'}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => router.back()}>
+               Cancel
+            </Button>
+         </div>
+      </form>
+   )
+}

--- a/apps/admin/src/app/(dashboard)/(routes)/suppliers/[supplierId]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/suppliers/[supplierId]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from 'next/navigation'
+import prisma from '@/lib/prisma'
+import { Heading } from '@/components/ui/heading'
+import { Separator } from '@/components/ui/separator'
+import { SupplierForm } from './components/supplier-form'
+
+interface Props {
+   params: Promise<{ supplierId: string }>
+}
+
+export default async function SupplierPage(props: Props) {
+   const params = await props.params
+   const supplierId = params.supplierId
+
+   const supplier = supplierId === 'new'
+      ? null
+      : await prisma.supplier.findUnique({ where: { id: supplierId } })
+
+   if (supplierId !== 'new' && !supplier) {
+      notFound()
+   }
+
+   return (
+      <div className="container mx-auto py-6">
+         <Heading title={supplier ? 'Edit Supplier' : 'Add Supplier'} description={supplier ? 'Edit supplier details' : 'Add a new supplier'} />
+         <Separator className="my-6" />
+         <SupplierForm initialData={supplier} />
+      </div>
+   )
+}

--- a/apps/admin/src/app/(dashboard)/(routes)/suppliers/components/table.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/suppliers/components/table.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { DataTable } from '@/components/ui/data-table'
+import { ColumnDef } from '@tanstack/react-table'
+import { EditIcon, TrashIcon } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { toast } from 'react-hot-toast'
+
+interface SuppliersTableProps {
+   data: SupplierColumn[]
+}
+
+export const SuppliersTable: React.FC<SuppliersTableProps> = ({ data }) => {
+   return <DataTable searchKey="name" columns={columns} data={data} />
+}
+
+export type SupplierColumn = {
+   id: string
+   name: string
+   phone: string
+   email: string
+   address: string
+   productCount: number
+}
+
+function DeleteButton({ supplierId }: { supplierId: string }) {
+   const router = useRouter()
+   const [loading, setLoading] = useState(false)
+
+   const handleDelete = async () => {
+      if (!confirm('Are you sure you want to delete this supplier?')) return
+      setLoading(true)
+      try {
+         const res = await fetch(`/api/suppliers/${supplierId}`, { method: 'DELETE' })
+         if (!res.ok) throw new Error()
+         toast.success('Supplier deleted.')
+         router.refresh()
+      } catch {
+         toast.error('Failed to delete supplier.')
+      } finally {
+         setLoading(false)
+      }
+   }
+
+   return (
+      <Button size="icon" variant="outline" onClick={handleDelete} disabled={loading}>
+         <TrashIcon className="h-4" />
+      </Button>
+   )
+}
+
+export const columns: ColumnDef<SupplierColumn>[] = [
+   {
+      accessorKey: 'name',
+      header: 'Name',
+   },
+   {
+      accessorKey: 'phone',
+      header: 'Phone',
+   },
+   {
+      accessorKey: 'email',
+      header: 'Email',
+   },
+   {
+      accessorKey: 'address',
+      header: 'Address',
+      cell: ({ row }) => (
+         <span className="text-sm text-muted-foreground">{row.original.address || '-'}</span>
+      ),
+   },
+   {
+      accessorKey: 'productCount',
+      header: 'Products',
+      cell: ({ row }) => (
+         <span className="text-sm">{row.original.productCount}</span>
+      ),
+   },
+   {
+      id: 'actions',
+      cell: ({ row }) => (
+         <div className="flex gap-1">
+            <Link href={`/suppliers/${row.original.id}`}>
+               <Button size="icon" variant="outline">
+                  <EditIcon className="h-4" />
+               </Button>
+            </Link>
+            <DeleteButton supplierId={row.original.id} />
+         </div>
+      ),
+   },
+]

--- a/apps/admin/src/app/(dashboard)/(routes)/suppliers/loading.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/suppliers/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+   return <div className="py-6 animate-pulse"><div className="h-8 w-48 bg-muted rounded mb-4" /><div className="h-4 w-64 bg-muted rounded" /></div>
+}

--- a/apps/admin/src/app/(dashboard)/(routes)/suppliers/page.tsx
+++ b/apps/admin/src/app/(dashboard)/(routes)/suppliers/page.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@/components/ui/button'
+import { Heading } from '@/components/ui/heading'
+import { Separator } from '@/components/ui/separator'
+import prisma from '@/lib/prisma'
+import { Plus } from 'lucide-react'
+import Link from 'next/link'
+
+import { SuppliersTable } from './components/table'
+import { SupplierColumn } from './components/table'
+
+export default async function SuppliersPage() {
+   const suppliers = await prisma.supplier.findMany({
+      include: { _count: { select: { products: true } } },
+      orderBy: { createdAt: 'desc' },
+   })
+
+   const formattedSuppliers: SupplierColumn[] = suppliers.map((sup) => ({
+      id: sup.id,
+      name: sup.name,
+      phone: sup.phone || '',
+      email: sup.email || '',
+      address: sup.address || '',
+      productCount: sup._count.products,
+   }))
+
+   return (
+      <div className="block space-y-4 my-6">
+         <div className="flex items-center justify-between">
+            <Heading
+               title={`Suppliers (${suppliers.length})`}
+               description="Manage product suppliers"
+            />
+            <Link href="/suppliers/new">
+               <Button>
+                  <Plus className="mr-2 h-4" /> Add New
+               </Button>
+            </Link>
+         </div>
+         <Separator />
+         {suppliers.length > 0 ? (
+            <SuppliersTable data={formattedSuppliers} />
+         ) : (
+            <div className="text-center py-10 text-neutral-500">
+               No suppliers yet. Add your first supplier to get started.
+            </div>
+         )}
+      </div>
+   )
+}

--- a/apps/admin/src/app/api/categories/[id]/route.ts
+++ b/apps/admin/src/app/api/categories/[id]/route.ts
@@ -1,0 +1,82 @@
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
+import { UTApi } from 'uploadthing/server'
+
+const utapi = new UTApi()
+
+export async function GET(req: Request, props: { params: Promise<{ id: string }> }) {
+   const params = await props.params
+   try {
+      const category = await prisma.category.findUnique({
+         where: { id: params.id },
+         include: { _count: { select: { products: true } } },
+      })
+      if (!category) return new NextResponse('Category not found', { status: 404 })
+      return NextResponse.json(category)
+   } catch (error) {
+      console.error('[CATEGORY_GET]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}
+
+export async function PATCH(req: Request, props: { params: Promise<{ id: string }> }) {
+   const params = await props.params
+   try {
+      const body = await req.json()
+      const { name, description, image, type, position, isActive } = body
+
+      const updateData: any = {
+         description: description,
+         image: image,
+         type: type,
+         position: position ? parseInt(position) : undefined,
+         isActive: isActive,
+      }
+
+      if (name) {
+         const baseSlug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+         const existing = await prisma.category.findUnique({ where: { slug: baseSlug } })
+         if (!existing || existing.id === params.id) updateData.slug = baseSlug
+         else {
+            let slug = baseSlug; let counter = 1
+            while (await prisma.category.findUnique({ where: { slug } })) { slug = `${baseSlug}-${counter}`; counter++ }
+            updateData.slug = slug
+         }
+         updateData.name = name
+      }
+
+      const category = await prisma.category.update({ where: { id: params.id }, data: updateData })
+      revalidatePath('/categories')
+      revalidatePath(`/categories/${category.slug}`)
+      return NextResponse.json(category)
+   } catch (error) {
+      console.error('[CATEGORY_PATCH]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}
+
+export async function DELETE(req: Request, props: { params: Promise<{ id: string }> }) {
+   const params = await props.params
+   try {
+      if (!params.id) return new NextResponse('Category ID required', { status: 400 })
+
+      const category = await prisma.category.findUnique({
+         where: { id: params.id },
+         select: { image: true },
+      })
+      if (!category) return new NextResponse('Category not found', { status: 404 })
+
+      if (category.image) {
+         const m = category.image.match(/\/f\/([^/?#]+)/)
+         if (m) await utapi.deleteFiles(m[1]).catch((err) => console.error('[UT_DELETE]', err))
+      }
+
+      await prisma.category.delete({ where: { id: params.id } })
+      revalidatePath('/categories')
+      return NextResponse.json({ success: true })
+   } catch (error) {
+      console.error('[CATEGORY_DELETE]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}

--- a/apps/admin/src/app/api/categories/route.ts
+++ b/apps/admin/src/app/api/categories/route.ts
@@ -1,0 +1,46 @@
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+   try {
+      const categories = await prisma.category.findMany({
+         include: { _count: { select: { products: true } } },
+         orderBy: [{ type: 'asc' }, { position: 'asc' }],
+      })
+      return NextResponse.json(categories)
+   } catch (error) {
+      console.error('[CATEGORIES_GET]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}
+
+export async function POST(req: Request) {
+   try {
+      const body = await req.json()
+      const { name, description, image, type, position, isActive } = body
+
+      const baseSlug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+      let slug = baseSlug
+      let counter = 1
+      while (await prisma.category.findUnique({ where: { slug } })) {
+         slug = `${baseSlug}-${counter}`
+         counter++
+      }
+
+      const category = await prisma.category.create({
+         data: {
+            name,
+            slug,
+            description: description || '',
+            image: image || '',
+            type: type || 'STANDARD',
+            position: position ? parseInt(position) : 0,
+            isActive: isActive ?? true,
+         },
+      })
+      return NextResponse.json(category)
+   } catch (error) {
+      console.error('[CATEGORIES_POST]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}

--- a/apps/admin/src/app/api/suppliers/[id]/route.ts
+++ b/apps/admin/src/app/api/suppliers/[id]/route.ts
@@ -1,0 +1,53 @@
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
+
+export async function GET(req: Request, props: { params: Promise<{ id: string }> }) {
+   const params = await props.params
+   try {
+      const supplier = await prisma.supplier.findUnique({
+         where: { id: params.id },
+         include: { _count: { select: { products: true } } },
+      })
+      if (!supplier) return new NextResponse('Supplier not found', { status: 404 })
+      return NextResponse.json(supplier)
+   } catch (error) {
+      console.error('[SUPPLIER_GET]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}
+
+export async function PATCH(req: Request, props: { params: Promise<{ id: string }> }) {
+   const params = await props.params
+   try {
+      const body = await req.json()
+      const { name, phone, email, address } = body
+
+      const supplier = await prisma.supplier.update({
+         where: { id: params.id },
+         data: { name, phone, email, address },
+      })
+      revalidatePath('/suppliers')
+      return NextResponse.json(supplier)
+   } catch (error) {
+      console.error('[SUPPLIER_PATCH]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}
+
+export async function DELETE(req: Request, props: { params: Promise<{ id: string }> }) {
+   const params = await props.params
+   try {
+      if (!params.id) return new NextResponse('Supplier ID required', { status: 400 })
+
+      const supplier = await prisma.supplier.findUnique({ where: { id: params.id } })
+      if (!supplier) return new NextResponse('Supplier not found', { status: 404 })
+
+      await prisma.supplier.delete({ where: { id: params.id } })
+      revalidatePath('/suppliers')
+      return NextResponse.json({ success: true })
+   } catch (error) {
+      console.error('[SUPPLIER_DELETE]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}

--- a/apps/admin/src/app/api/suppliers/route.ts
+++ b/apps/admin/src/app/api/suppliers/route.ts
@@ -1,0 +1,35 @@
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+   try {
+      const suppliers = await prisma.supplier.findMany({
+         include: { _count: { select: { products: true } } },
+         orderBy: { createdAt: 'desc' },
+      })
+      return NextResponse.json(suppliers)
+   } catch (error) {
+      console.error('[SUPPLIERS_GET]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}
+
+export async function POST(req: Request) {
+   try {
+      const body = await req.json()
+      const { name, phone, email, address } = body
+
+      const supplier = await prisma.supplier.create({
+         data: {
+            name,
+            phone: phone || '',
+            email: email || '',
+            address: address || '',
+         },
+      })
+      return NextResponse.json(supplier)
+   } catch (error) {
+      console.error('[SUPPLIERS_POST]', error)
+      return new NextResponse('Internal error', { status: 500 })
+   }
+}

--- a/apps/admin/src/components/main-nav.tsx
+++ b/apps/admin/src/components/main-nav.tsx
@@ -22,6 +22,16 @@ export function MainNav({
          active: pathname.includes(`/brands`),
       },
       {
+         href: `/categories`,
+         label: 'Categories',
+         active: pathname.includes(`/categories`),
+      },
+      {
+         href: `/suppliers`,
+         label: 'Suppliers',
+         active: pathname.includes(`/suppliers`),
+      },
+      {
          href: `/banners`,
          label: 'Banners',
          active: pathname.includes(`/banners`),

--- a/apps/admin/src/lib/uploadthing.ts
+++ b/apps/admin/src/lib/uploadthing.ts
@@ -8,6 +8,11 @@ export const uploadRouter = {
          console.log('Upload complete:', file.ufsUrl)
          return { url: file.ufsUrl }
       }),
+   categoryImage: f({ image: { maxFileSize: '4MB', maxFileCount: 1 } }, { awaitServerData: false })
+      .onUploadComplete(({ file }) => {
+         console.log('Upload complete:', file.ufsUrl)
+         return { url: file.ufsUrl }
+      }),
 } satisfies FileRouter
 
 export type UploadRouter = typeof uploadRouter

--- a/apps/storefront/prisma/schema.prisma
+++ b/apps/storefront/prisma/schema.prisma
@@ -65,6 +65,58 @@ model Banner {
   updatedAt DateTime @updatedAt
 }
 
+model Category {
+  id          String     @id @default(cuid())
+  name        String
+  slug        String     @unique
+  description String?    @db.Text
+  image       String?
+  type        String     @default("STANDARD")
+  position    Int        @default(0)
+  isActive   Boolean    @default(true)
+
+  products  Product[]
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  @@index([slug])
+}
+
+model Supplier {
+  id        String   @id @default(cuid())
+  name      String
+  phone     String?
+  email     String?
+  address   String?
+
+  products Product[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Product {
+  id          String   @id @default(cuid())
+  name        String
+  slug        String   @unique
+  description String?  @db.Text
+  price       Float    @default(0)
+  images      String[]
+  stock       Int      @default(0)
+  sku         String?
+
+  category   Category? @relation(fields: [categoryId], references: [id])
+  categoryId String?
+  supplier   Supplier? @relation(fields: [supplierId], references: [id])
+  supplierId String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([slug])
+  @@index([categoryId])
+  @@index([supplierId])
+}
+
 model SiteConfig {
   id              String  @id @default(cuid())
   defaultWhatsApp String?

--- a/opencode.json
+++ b/opencode.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://opencode.ai/config.json",
   "plugin": ["superpowers@git+https://github.com/obra/superpowers.git"]
 }


### PR DESCRIPTION
## Summary
- Categories list/create/edit/delete with UploadThing image upload
- Suppliers list/create/edit/delete (admin-only, never exposed on storefront)
- API routes: `/api/categories` and `/api/suppliers` with full CRUD
- Navigation links added to MainNav
- Build passes for admin app

## Test Plan
- [x] `pnpm build` passes
- [x] Categories API routes return correct data
- [x] Suppliers API routes return correct data
- [x] Nav shows Categories and Suppliers links

Closes #58